### PR TITLE
Unscramble bottom sections

### DIFF
--- a/magnustools/ToolforgeCommon.php
+++ b/magnustools/ToolforgeCommon.php
@@ -298,7 +298,7 @@ final class ToolforgeCommon {
 
 		$f1 = preg_replace ( '/<body>.*/ms' , "<body>\n" , $f1 ) ;
 		$f1 = preg_replace ( '/<script src=".\/main.js"><\/script>\s*/' , '' , $f1 ) ;
-		$f3 = '<div id="main_content" class="container"><div class="row"><div class="col-sm-12" style="margin-bottom:20px;margin-top:10px;">' ;
+		$f3 = '<div id="main_content" class="container"><div><div class="col-sm-12" style="margin-bottom:20px;margin-top:10px;">' ;
 
 		return "$f1$f2$f3\n" ;
 	}


### PR DESCRIPTION
Close #147

Currently flexbox "row" is applied to the contents of "main_content" even though the site has a column based layout. "column" could be applied instead but is not necessary unless other flexbox properties are used.

Tested manually in browser. Let me know if there are any problems in testing.