### PR TITLE
Modifying QS statements to add "occupation: researcher" by default

### DIFF
--- a/lib/qs_commands.php
+++ b/lib/qs_commands.php
@@ -8,6 +8,7 @@ function new_author_qs_commands ( $name, $orcid_author, $viaf_author, $researchg
 	$commands[] = "CREATE" ;
 	$commands[] = "LAST\tLen\t\"$name\""  ;
 	$commands[] = "LAST\t$instance_prop_id\t$human_qid"  ;
+	$commands[] = "LAST\t$occupation_prop_id\t$researcher_qid"  ;
 	if ( $orcid_author != '' ) $commands[] = "LAST\tP496\t\"$orcid_author\"" ;
 	if ( $viaf_author != '' ) $commands[] = "LAST\tP214\t\"$viaf_author\"" ;
 	if ( $researchgate_author != '' ) $commands[] = "LAST\tP2038\t\"$researchgate_author\"" ;

--- a/lib/wikibase_config.php
+++ b/lib/wikibase_config.php
@@ -10,6 +10,7 @@ $reasonator_prefix = 'https://reasonator.toolforge.org/?q=';
 $sqid_prefix = 'https://sqid.toolforge.org/#/view?id=';
 
 $human_qid = 'Q5';
+$researcher_qid = 'Q1650915';
 $human_group_qid = 'Q16334295';
 $instance_prop_id = 'P31';
 $subclass_prop_id = 'P279';
@@ -24,6 +25,7 @@ $topic_prop_id = 'P921';
 $title_prop_id = 'P1476';
 $doi_prop_id = 'P356';
 $pubmed_prop_id = 'P698';
+$occupation_prop_id = 'P106';
 $identifier_prop_ids = ['P496','P213','P1053','P214','P2038'];
 $identifier_details = [
 	'P213' => ['label' => 'ISNI', 'url_prefix' => 'http://isni.org/'],


### PR DESCRIPTION
When people unfamiliar with the target item and/ or with WikiCite workflows find an item that has only the English label and the "instance of human" statements, they are often irritated and would like to have some more information. Of course, that is usually available via items connected to the target item, but perhaps adding this "occupation: researcher" statement is generally more helpful than not having it.
