### PR TITLE
Change ORCID URL

### DIFF
--- a/lib/display_code.php
+++ b/lib/display_code.php
@@ -11,7 +11,7 @@ function wikidata_link ( $q, $text, $color ) {
 }
 
 function getORCIDurl ( $s ) {
-	return "https://orcid.org/orcid-search/quick-search?searchQuery=" . urlencode($s) ;
+	return "https://orcid.org/orcid-search/search?searchQuery=" . urlencode($s) ;
 }
 
 function print_footer () {


### PR DESCRIPTION
The old URL version currently gives an error: https://orcid.org/orcid-search/quick-search?searchQuery=Leyla+Ruzicka
The new version works fine: https://orcid.org/orcid-search/search?searchQuery=Leyla%20Ruzicka