### PR TITLE
Update names_oauth.php to put DOI string in quotes

### DIFF
--- a/names_oauth.php
+++ b/names_oauth.php
@@ -371,7 +371,7 @@ foreach ( $clusters AS $cluster_name => $cluster ) {
                 print "<td style='font-size:9pt'>" ;
 		if ( $article->doi != '' ) {
 			print "DOI: <a target='_blank' href='https://doi.org/$article->doi'>$article->doi</a>" ;
-			print "&nbsp;[<a href='" . getORCIDurl ( $article->doi ) . "'>ORCID</a>]<br/>" ;
+			print "&nbsp;[<a href='" . getORCIDurl ( "'" . $article->doi . "'" ) . "'>ORCID</a>]<br/>" ;
 		}
 		if ( $article->pmid != '' ) {
 			print "PubMed: <a target='_blank' href='https://www.ncbi.nlm.nih.gov/pubmed/?term=$article->pmid'>$article->pmid</a>" ;


### PR DESCRIPTION
This puts quotes around the query string for the DOI, before URL encoding. This improved findability of records associated with the DOI.

Example:
* before: https://orcid.org/orcid-search/search?searchQuery=10.1016%2FJ.AJEM.2011.03.013
![Screenshot from 2023-12-18 16-30-08](https://github.com/arthurpsmith/author-disambiguator/assets/465923/b1c7438d-9883-4612-8503-07bb6727f256)

* after: https://orcid.org/orcid-search/search?searchQuery=%2210.1016%2FJ.AJEM.2011.03.013%22
![Screenshot from 2023-12-18 16-31-58](https://github.com/arthurpsmith/author-disambiguator/assets/465923/1fff4951-fe5f-4496-a02d-e9c432d9dde3)
